### PR TITLE
Update: Check pending message by messageId instead of by message body

### DIFF
--- a/src/components/PartyChat/PartyChat.jsx
+++ b/src/components/PartyChat/PartyChat.jsx
@@ -53,7 +53,7 @@ export default function PartyChat({party, inParty}) {
     if(lastMessage!==null) {
       if(lastMessage.senderId === user.id) {
         for(let i = 0; i < pendingMessages.length; i++) {
-          if(pendingMessages[i].body === lastMessage.body) {
+          if(pendingMessages[i].messageId === lastMessage.messageId) {
             setPendingMessages([...pendingMessages.slice(0,i), ...pendingMessages.slice(i+1)])
             break;
           }
@@ -74,7 +74,7 @@ export default function PartyChat({party, inParty}) {
 
   const handleSendMessage = () => {
     if(newMessage !== "") {
-      sendMessage(newMessage, party);
+      sendMessage(newMessage, party, pendingMessages.length > 0 ? pendingMessages[pendingMessages.length-1].messageId+1 : 0);
       setNewMessage("");
     }
   };

--- a/src/hooks/useChat.jsx
+++ b/src/hooks/useChat.jsx
@@ -19,21 +19,22 @@ export default function useChat (partyId, setMessages, setLastMessage, pendingMe
     socketRef.current = socketIOClient(CHAT_SERVER_URL, {query: {partyId}
   })
     const chatMessageEvent = async() => {
-      socketRef.current.on(NEW_CHAT_MESSAGE_EVENT, async (message) => {       let userSender
-      try {
-        const response = await axios.get(`${BACKEND_URL}user/${message.senderId}`)
-        userSender = response.data.user
-      }
-      catch (err) {
-        return;
-      }
-      const incomingMessage = {
-        ...message,
-        user: userSender,
-        ownedByCurrentUser: message.senderId === curUser.id
-      };
-      setMessages((messages) => [...messages, incomingMessage])
-      setLastMessage(message)
+      socketRef.current.on(NEW_CHAT_MESSAGE_EVENT, async (message) => {
+        let userSender
+        try {
+          const response = await axios.get(`${BACKEND_URL}user/${message.senderId}`)
+          userSender = response.data.user
+        }
+        catch (err) {
+          return;
+        }
+        const incomingMessage = {
+          ...message,
+          user: userSender,
+          ownedByCurrentUser: message.senderId === curUser.id
+        };
+        setMessages((messages) => [...messages, incomingMessage])
+        setLastMessage(message)
       })
   }
     chatMessageEvent()
@@ -44,14 +45,15 @@ export default function useChat (partyId, setMessages, setLastMessage, pendingMe
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [partyId, curUser.id]);
 
-  const sendMessage = async (messageBody, party) => {
+  const sendMessage = async (messageBody, party, messageId) => {
     const currentUser = await getCurrentUser();
-    setPendingMessages([...pendingMessages, {body: messageBody, senderId: currentUser.id, user: {username: currentUser.username, picture: currentUser.picture}}])
+    setPendingMessages([...pendingMessages, {body: messageBody, senderId: currentUser.id, user: {username: currentUser.username, picture: currentUser.picture}, messageId: messageId}])
 
     socketRef.current.emit(NEW_CHAT_MESSAGE_EVENT, {
       body: messageBody,
       senderId: currentUser.id,
-      partyId: party.party.objectId
+      partyId: party.party.objectId,
+      messageId: messageId
     })
   }
 


### PR DESCRIPTION
## What
Remove messages from pending array based on messageId instead of the message body

## Why
Better handling of messages with duplicate content (bodies may be identical, but the messageIds are distinct)