### PR TITLE
Load more button disabled css

### DIFF
--- a/src/components/PartyChat/PartyChat.css
+++ b/src/components/PartyChat/PartyChat.css
@@ -103,6 +103,10 @@
   border-color: rgb(0, 0, 0);
 }
 
+.load-more-messages:disabled {
+  background-color: #bcbcbc;
+  color: gray;
+}
 
 @media screen and (max-width: 800px) {
   .party-chat {


### PR DESCRIPTION
## What
Visual indicator that there are no more messages to load (button is grayed out)

## Why
Helps users recognize they've reached the top of the message history