### PR TITLE
Display: Display party relevance in search results

### DIFF
--- a/src/components/SearchCard/SearchCard.css
+++ b/src/components/SearchCard/SearchCard.css
@@ -36,14 +36,6 @@ grid-column: 2 / span 1;
 grid-row: 2 / span 1;
 }
 
-.search-party-card .green {
-background-color: rgba(0, 154, 0, 0.7);	
-}
-
-.search-party-card .purple {
-background-color: rgba(95, 77, 172, 0.7);
-}
-
 .search-params-list {
 grid-column: 3 / span 1;
 grid-row: 1 / span 2;

--- a/src/components/SearchCard/SearchCard.jsx
+++ b/src/components/SearchCard/SearchCard.jsx
@@ -2,16 +2,28 @@ import * as React from 'react'
 import "./SearchCard.css"
 import { Link } from 'react-router-dom';
 import SearchParamsList from '../SearchParamsList/SearchParamsList.jsx';
-import classNames from 'classnames';
 
 export default function SearchCard({party}) {
+  function getGradient(ratio) {
+    var color1 = '90ee90'; // lightgreen
+    var color2 = 'FF0000'; // red
+    var hex = function(x) {
+        x = x.toString(16);
+        return (x.length === 1) ? '0' + x : x;
+    };
+
+    var r = Math.ceil(parseInt(color1.substring(0,2), 16) * ratio + parseInt(color2.substring(0,2), 16) * (1-ratio));
+    var g = Math.ceil(parseInt(color1.substring(2,4), 16) * ratio + parseInt(color2.substring(2,4), 16) * (1-ratio));
+    var b = Math.ceil(parseInt(color1.substring(4,6), 16) * ratio + parseInt(color2.substring(4,6), 16) * (1-ratio));
+    return '#' + hex(r) + hex(g) + hex(b);
+  }
   return (
     <li className="search-party-card">
       <div className="search-party-image">
         <img src={party.image} alt={party.name}/>
       </div>
       <div className="search-party-title">{party.name}</div>
-      <div className={classNames({"search-party-status": true, "green": party.status="public", "purple": party.status="private"})}>{party.status.charAt(0).toUpperCase() + party.status.slice(1)}</div>
+      <div className="search-party-status" style={{backgroundColor: getGradient((party.relevance)/100)}}>{party.relevance}</div>
       <SearchParamsList party={party} />
       <div className="enter-dungeon-button-container">
           <Link to={`/party/${party.objectId}`}>


### PR DESCRIPTION
## What
Display party relevance in the search card when finding parties

## Why
Allows users to quickly see how relevant a party is to their search criteria. Additionally, coloring that follows a gradient scale from green to red based on relevance is put as the background so users have an easier visual as to the relevance of a party.