### PR TITLE
Display: Show sender information on new day

### DIFF
--- a/src/components/PartyChat/PartyChat.jsx
+++ b/src/components/PartyChat/PartyChat.jsx
@@ -246,16 +246,18 @@ function ChatMessage({ message, prevMessage, pendingMessage }) {
         padTo2Digits(messageDate.getMinutes()) +
         " am";
 
-  const newSender =
-    prevMessage === undefined ||
-    prevMessage === true ||
-    prevMessage.senderId !== message.senderId;
   const newDate =
     prevMessage === undefined ||
     prevMessage === true ||
     prevMessageDate.getFullYear() !== messageDate.getFullYear() ||
     prevMessageDate.getMonth() !== messageDate.getMonth() ||
     prevMessageDate.getDate() !== messageDate.getDate();
+  
+  const newSender =
+    prevMessage === undefined ||
+    prevMessage === true ||
+    prevMessage.senderId !== message.senderId ||
+    newDate;
   const liClassNames = classNames({
     "message-item": true,
     "my-message": message.ownedByCurrentUser,


### PR DESCRIPTION
## What
Show user data when sending message on new day

## Why
Better visuals: prevents confusion as to who sent message when date interrupts message flow